### PR TITLE
Enable Add Task from More link

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -346,10 +346,16 @@ struct ContentView: View {
                 }
                 
                 if tasks.count > 5 {
-                    Text("More...")
-                        .font(.caption)
-                        .foregroundColor(color)
-                        .fontWeight(.medium)
+                    Button(action: {
+                        selectedPriorityForAdd = priority
+                        showingAddTask = true
+                    }) {
+                        Text("More...")
+                            .font(.caption)
+                            .foregroundColor(color)
+                            .fontWeight(.medium)
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
             


### PR DESCRIPTION
## Summary
- make More button open Add Task sheet for that quadrant

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688efd5559d883299e9d0da0896991cf