### PR TITLE
Add offline user-specific task persistence

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -82,11 +82,34 @@ enum TaskPriority: String, CaseIterable, Codable {
 // MARK: - Data Manager
 class TaskManager: ObservableObject {
     @Published var tasks: [TaskItem] = []
-    
-    init() {
-        loadSampleData()
+    private let userId: String
+
+    init(userId: String) {
+        self.userId = userId
+        loadTasks()
+        if tasks.isEmpty {
+            loadSampleData()
+        }
     }
-    
+
+    private func fileURL() -> URL {
+        let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return urls[0].appendingPathComponent("tasks_\(userId).json")
+    }
+
+    private func loadTasks() {
+        let url = fileURL()
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([TaskItem].self, from: data) else { return }
+        tasks = decoded
+    }
+
+    private func saveTasks() {
+        let url = fileURL()
+        guard let data = try? JSONEncoder().encode(tasks) else { return }
+        try? data.write(to: url)
+    }
+
     func addTask(title: String, description: String, priority: TaskPriority) {
         let newTask = TaskItem(
             title: title,
@@ -94,9 +117,10 @@ class TaskManager: ObservableObject {
             priority: priority
         )
         tasks.append(newTask)
+        saveTasks()
     }
-    
-    func loadSampleData() {
+
+    private func loadSampleData() {
         tasks = [
             // Urgent & Important - 7 tasks (will show 5 + "More...")
             TaskItem(title: "Deadline project", description: "Complete urgent project", priority: .urgentImportant),
@@ -127,43 +151,48 @@ class TaskManager: ObservableObject {
     func toggleTask(_ task: TaskItem) {
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             tasks[index].isCompleted.toggle()
+            saveTasks()
         }
     }
-    
+
     func deleteTask(_ task: TaskItem) {
         tasks.removeAll { $0.id == task.id }
+        saveTasks()
     }
-    
+
     func tasksForPriority(_ priority: TaskPriority) -> [TaskItem] {
         return tasks.filter { $0.priority == priority }
     }
-    
+
     func moveTask(_ task: TaskItem, to newPriority: TaskPriority) {
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             tasks[index].priority = newPriority
+            saveTasks()
         }
     }
-    
+
     func reorderTasks(from sourceIndex: Int, to destinationIndex: Int, in priority: TaskPriority) {
         let priorityTasks = tasksForPriority(priority)
         guard sourceIndex < priorityTasks.count && destinationIndex < priorityTasks.count else { return }
-        
+
         let sourceTask = priorityTasks[sourceIndex]
         let destinationTask = priorityTasks[destinationIndex]
-        
+
         // Find the actual indices in the main tasks array
         if let sourceIndexInMain = tasks.firstIndex(where: { $0.id == sourceTask.id }),
            let destIndexInMain = tasks.firstIndex(where: { $0.id == destinationTask.id }) {
             let task = tasks.remove(at: sourceIndexInMain)
             tasks.insert(task, at: destIndexInMain)
+            saveTasks()
         }
     }
-    
+
     func updateTask(_ task: TaskItem, title: String, description: String, priority: TaskPriority) {
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             tasks[index].title = title
             tasks[index].description = description
             tasks[index].priority = priority
+            saveTasks()
         }
     }
 }
@@ -175,7 +204,7 @@ class TaskManager: ObservableObject {
 
 // MARK: - Content View
 struct ContentView: View {
-    @StateObject private var taskManager = TaskManager()
+    @ObservedObject var taskManager: TaskManager
     @State private var selectedPriority: TaskPriority?
     @State private var selectedPriorityForAdd: TaskPriority?
     @State private var selectedTask: TaskItem?
@@ -796,5 +825,5 @@ extension TaskPriority: Identifiable {
 }
 
 #Preview {
-    ContentView()
+    ContentView(taskManager: TaskManager(userId: "preview"))
 }

--- a/EisenhowerMatrixApp/EisenhowerMatrixAppApp.swift
+++ b/EisenhowerMatrixApp/EisenhowerMatrixAppApp.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 @main
 struct EisenhowerMatrixAppApp: App {
+    @State private var currentUser: String?
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if let user = currentUser {
+                ContentView(taskManager: TaskManager(userId: user))
+            } else {
+                LoginView { username in
+                    currentUser = username
+                }
+            }
         }
     }
 }

--- a/EisenhowerMatrixApp/LoginView.swift
+++ b/EisenhowerMatrixApp/LoginView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var username: String = ""
+    var onLogin: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Eisenhower Matrix")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            TextField("Enter username", text: $username)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+
+            Button("Login") {
+                let trimmed = username.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else { return }
+                onLogin(trimmed)
+            }
+            .padding()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    LoginView { _ in }
+}


### PR DESCRIPTION
## Summary
- Persist tasks locally per user via TaskManager with JSON storage
- Introduce login view to load tasks for each username
- Launch app to login screen and load persisted tasks on login

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efe0799a08329a483eefee687bb3c