### PR TITLE
Improve readability on dark and gray backgrounds

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -295,7 +295,7 @@ struct ContentView: View {
     @State private var showingTaskDetail = false
     @State private var isDragging = false
     @State private var draggedTaskId: UUID?
-    @State private var backgroundMode: BackgroundMode = .gray
+    @State private var backgroundMode: BackgroundMode = .white
     
     var body: some View {
         NavigationView {
@@ -364,6 +364,7 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backgroundMode.color.ignoresSafeArea())
     }
+    .preferredColorScheme(backgroundMode == .white ? .light : .dark)
     .sheet(isPresented: $showingAddTask) {
         AddTaskView(taskManager: taskManager, priority: selectedPriorityForAdd ?? .urgentImportant)
     }


### PR DESCRIPTION
## Summary
- default to white background for initial appearance
- use preferredColorScheme to keep text legible on dark or gray backgrounds

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f01db1f248329afc667523f18e44b