### PR TITLE
Fix drag and drop handling in matrix quadrants

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -255,6 +255,10 @@ struct TaskDropDelegate: DropDelegate {
         }
     }
 
+    func dropUpdated(_ info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
     func performDrop(info: DropInfo) -> Bool {
         draggedTaskId = nil
         return true
@@ -265,6 +269,10 @@ struct QuadrantDropDelegate: DropDelegate {
     let priority: TaskPriority
     let taskManager: TaskManager
     @Binding var draggedTaskId: UUID?
+
+    func dropUpdated(_ info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
 
     func performDrop(info: DropInfo) -> Bool {
         guard let draggedId = draggedTaskId,
@@ -484,7 +492,6 @@ struct ContentView: View {
                     .buttonStyle(PlainButtonStyle())
                 }
             }
-            .onDrop(of: [UTType.text], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
 
             Spacer()
             
@@ -514,6 +521,7 @@ struct ContentView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(color, lineWidth: 1)
         )
+        .onDrop(of: [UTType.text], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure drag interactions are treated as move operations
- allow dropping tasks anywhere inside a quadrant

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_688f01fc0ec483299c50c8dac726ab87