### PR TITLE
Ensure Add Task button visible with More

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -419,7 +419,7 @@ struct ContentView: View {
                                 .font(.caption)
                         }
                         .buttonStyle(PlainButtonStyle())
-                        
+
                         VStack(alignment: .leading, spacing: 1) {
                             Text(task.title)
                                 .font(.caption)
@@ -430,7 +430,7 @@ struct ContentView: View {
                                     selectedTask = task
                                     showingTaskDetail = true
                                 }
-                            
+
                             Text(task.description)
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
@@ -440,14 +440,14 @@ struct ContentView: View {
                                     showingTaskDetail = true
                                 }
                         }
-                        
+
                         Spacer()
-                        
+
                         // Drag handle indicator
                         Image(systemName: "line.3.horizontal")
                             .foregroundColor(color.opacity(0.6))
                             .font(.caption2)
-                        
+
                         Button(action: {
                             taskManager.deleteTask(task)
                         }) {
@@ -471,39 +471,39 @@ struct ContentView: View {
                     .onDrop(of: [UTType.text], delegate: TaskDropDelegate(task: task, taskManager: taskManager, currentPriority: priority, draggedTaskId: $draggedTaskId))
                 }
 
-                if tasks.count > 5 {
+                HStack {
+                    if tasks.count > 5 {
+                        Button(action: {
+                            selectedPriority = priority
+                            showingDetail = true
+                        }) {
+                            Text("More...")
+                                .font(.caption)
+                                .foregroundColor(color)
+                                .fontWeight(.medium)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+
+                    Spacer()
+
                     Button(action: {
                         selectedPriorityForAdd = priority
                         showingAddTask = true
                     }) {
-                        Text("More...")
-                            .font(.caption)
-                            .foregroundColor(color)
-                            .fontWeight(.medium)
+                        HStack {
+                            Image(systemName: "plus.circle.fill")
+                                .foregroundColor(color)
+                                .font(.caption)
+                            Text("Add Task")
+                                .font(.caption)
+                                .foregroundColor(color)
+                        }
                     }
                     .buttonStyle(PlainButtonStyle())
                 }
             }
             .onDrop(of: [UTType.text], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
-
-            Spacer()
-            
-            // Add button
-            Button(action: {
-                selectedPriorityForAdd = priority
-                showingAddTask = true
-            }) {
-                HStack {
-                    Image(systemName: "plus.circle.fill")
-                        .foregroundColor(color)
-                        .font(.caption)
-                    Text("Add Task")
-                        .font(.caption)
-                        .foregroundColor(color)
-                }
-            }
-            .buttonStyle(PlainButtonStyle())
-            
             Spacer()
         }
         .padding(8)


### PR DESCRIPTION
## Summary
- keep Add Task button visible alongside More button in matrix quadrants
- More now opens the full priority detail view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f025ae4f083299d6c60cb187c3712