### PR TITLE
Center align quadrant titles

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -386,6 +386,8 @@ struct ContentView: View {
             // Header with title - clickable to open full list
             VStack(spacing: 4) {
                 HStack {
+                    Spacer()
+
                     Image(systemName: priority.icon)
                         .foregroundColor(color)
                         .font(.title3)
@@ -394,15 +396,14 @@ struct ContentView: View {
                         .font(.caption2)
                         .fontWeight(.bold)
                         .foregroundColor(color)
-                        .multilineTextAlignment(.leading)
+                        .multilineTextAlignment(.center)
                         .lineLimit(2)
-                        .frame(maxWidth: .infinity, alignment: .leading)
                         .minimumScaleFactor(0.8)
                         .onTapGesture {
                             selectedPriority = priority
                             showingDetail = true
                         }
-                    
+
                     Spacer()
                 }
             }


### PR DESCRIPTION
## Summary
- center quadrant header titles to improve layout consistency

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme EisenhowerMatrixApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f026b273c83298166c2b7d11fb3a5