### PR TITLE
Fix drag-and-drop UTType

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -455,7 +455,7 @@ struct ContentView: View {
                         draggedTaskId = task.id
                         return NSItemProvider(object: task.id.uuidString as NSString)
                     }
-                    .onDrop(of: [UTType.text], delegate: TaskDropDelegate(task: task, taskManager: taskManager, currentPriority: priority, draggedTaskId: $draggedTaskId))
+                    .onDrop(of: [UTType.plainText], delegate: TaskDropDelegate(task: task, taskManager: taskManager, currentPriority: priority, draggedTaskId: $draggedTaskId))
                 }
 
                 HStack {
@@ -490,7 +490,7 @@ struct ContentView: View {
                     .buttonStyle(PlainButtonStyle())
                 }
             }
-            .onDrop(of: [UTType.text], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
+            .onDrop(of: [UTType.plainText], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
             Spacer()
         }
         .padding(8)
@@ -500,7 +500,7 @@ struct ContentView: View {
             Rectangle()
                 .stroke(color, lineWidth: 1)
         )
-        .onDrop(of: [UTType.text], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
+        .onDrop(of: [UTType.plainText], delegate: QuadrantDropDelegate(priority: priority, taskManager: taskManager, draggedTaskId: $draggedTaskId))
     }
 }
 


### PR DESCRIPTION
## Summary
- use `UTType.plainText` for drag-and-drop handlers so tasks move within and across quadrants

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme EisenhowerMatrixApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f0623fc7083299d537f40c4725cf7