### PR TITLE
Lighten gray theme for better readability

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -62,7 +62,7 @@ enum TaskPriority: String, CaseIterable, Codable {
         case .urgentImportant: return SwiftUI.Color.red
         case .urgentNotImportant: return SwiftUI.Color.orange
         case .notUrgentImportant: return SwiftUI.Color.blue
-        case .notUrgentNotImportant: return SwiftUI.Color.gray
+        case .notUrgentNotImportant: return SwiftUI.Color(red: 0.7, green: 0.7, blue: 0.7)
         }
     }
     
@@ -94,7 +94,7 @@ enum BackgroundMode: String, CaseIterable, Identifiable {
         case .dark:
             return .black
         case .gray:
-            return .gray
+            return Color(red: 0.7, green: 0.7, blue: 0.7)
         case .white:
             return .white
         }


### PR DESCRIPTION
## Summary
- Soften the gray used for not urgent & not important tasks to improve contrast
- Lighten the gray background option so text stands out more

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f06e406308329af1d6668ce2b6bbd