### PR TITLE
Fix TaskPriority Identifiable conformance

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -923,9 +923,6 @@ struct TaskDetailView: View {
     }
 }
 
-extension TaskPriority: Identifiable {
-    var id: String { rawValue }
-}
 
 #Preview {
     ContentView(taskManager: TaskManager(userId: "preview"))


### PR DESCRIPTION
## Summary
- Remove redundant `TaskPriority` `Identifiable` extension

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688f07d14da883299dc61232b567c524