### PR TITLE
Enable opening task details from main screen

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -421,19 +421,11 @@ struct ContentView: View {
                                 .fontWeight(.medium)
                                 .strikethrough(task.isCompleted)
                                 .lineLimit(1)
-                                .onTapGesture {
-                                    selectedTask = task
-                                    showingTaskDetail = true
-                                }
 
                             Text(task.description)
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
                                 .lineLimit(1)
-                                .onTapGesture {
-                                    selectedTask = task
-                                    showingTaskDetail = true
-                                }
                         }
 
                         Spacer()
@@ -450,6 +442,11 @@ struct ContentView: View {
                                 .font(.caption)
                         }
                         .buttonStyle(PlainButtonStyle())
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        selectedTask = task
+                        showingTaskDetail = true
                     }
                     .padding(.horizontal, 6)
                     .padding(.vertical, 3)


### PR DESCRIPTION
## Summary
- show task detail when tapping anywhere on a task row

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f0a2fc7b483299f61ae827790a896