### PR TITLE
Enable scroll bar scrubbing in detail view

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -609,6 +609,7 @@ struct PriorityDetailView: View {
                     }
                 }
                 .listStyle(PlainListStyle())
+                .scrollIndicators(.visible)
             }
             .navigationTitle(priority.rawValue)
             .toolbar {


### PR DESCRIPTION
## Summary
- always show scroll indicator in quadrant detail view so users can drag to quickly browse tasks

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688f109f84c4832998349aa420051833