### PR TITLE
Remove drag instruction from matrix header

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -331,19 +331,6 @@ struct ContentView: View {
                     Text("Eisenhower Matrix")
                         .font(.largeTitle)
                         .fontWeight(.bold)
-
-                    HStack {
-                        Image(systemName: "hand.draw")
-                            .foregroundColor(.blue)
-                            .font(.caption)
-                        Text("Drag tasks between quadrants to change priority")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.horizontal)
-                    .padding(.vertical, 8)
-                    .background(Color.blue.opacity(0.1))
-                    .cornerRadius(8)
                 }
                 .padding()
 


### PR DESCRIPTION
## Summary
- remove drag instructions from header tip in ContentView

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f10c36af08329bc5a296d47d7bdae