### PR TITLE
Remove redundant Edit button and enlarge edit icon

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -608,11 +608,6 @@ struct PriorityDetailView: View {
                         Image(systemName: "plus")
                     }
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Edit") {
-                        // Edit mode functionality
-                    }
-                }
             }
         }
         .sheet(isPresented: $showingAddTask) {
@@ -722,7 +717,7 @@ struct TaskRowView: View {
             }) {
                 Image(systemName: "pencil")
                     .foregroundColor(.blue)
-                    .font(.caption)
+                    .font(.title3)
             }
             .buttonStyle(PlainButtonStyle())
             if let due = task.dueDate {


### PR DESCRIPTION
## Summary
- remove unused Edit toolbar item from priority task list
- enlarge pencil icon used to edit individual tasks

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f130b26088329b20f5840c5743605