### PR TITLE
Fix macOS build issues and clean warnings

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -223,7 +223,7 @@ class TaskManager: ObservableObject {
     }
 
     func reorderTasks(from sourceIndex: Int, to destinationIndex: Int, in priority: TaskPriority) {
-        var priorityTasks = tasksForPriority(priority)
+        let priorityTasks = tasksForPriority(priority)
         guard sourceIndex >= 0,
               sourceIndex < priorityTasks.count else { return }
 
@@ -546,7 +546,9 @@ struct PriorityDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showingAddTask = false
     @State private var showCompleted = false
+    #if os(iOS)
     @State private var editMode: EditMode = .inactive
+    #endif
     @Binding var draggedTaskId: UUID?
 
     var body: some View {
@@ -612,7 +614,9 @@ struct PriorityDetailView: View {
             }
             .listStyle(PlainListStyle())
             .scrollIndicators(.visible)
+#if os(iOS)
             .environment(\.editMode, $editMode)
+#endif
             .navigationTitle(priority.rawValue)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {


### PR DESCRIPTION
## Summary
- Fix Swift warning by using constant `priorityTasks`
- Wrap edit mode handling with `#if os(iOS)` to avoid macOS build errors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f194dac808329aac2b9f3dcba14ba