### PR TITLE
Add Apple and Google sign-in options

### DIFF
--- a/EisenhowerMatrixApp/LoginView.swift
+++ b/EisenhowerMatrixApp/LoginView.swift
@@ -1,4 +1,8 @@
 import SwiftUI
+import AuthenticationServices
+import GoogleSignIn
+import GoogleSignInSwift
+import UIKit
 
 struct LoginView: View {
     @State private var username: String = ""
@@ -20,6 +24,31 @@ struct LoginView: View {
                 onLogin(trimmed)
             }
             .padding()
+
+            SignInWithAppleButton(.signIn) { request in
+                request.requestedScopes = [.fullName, .email]
+            } onCompletion: { result in
+                if case .success(let authResults) = result,
+                   let credential = authResults.credential as? ASAuthorizationAppleIDCredential {
+                    onLogin(credential.user)
+                }
+            }
+            .signInWithAppleButtonStyle(.black)
+            .frame(height: 45)
+            .padding(.horizontal)
+
+            GoogleSignInButton {
+                guard let root = UIApplication.shared.connectedScenes
+                        .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
+                        .first?.rootViewController else { return }
+                GIDSignIn.sharedInstance.signIn(withPresenting: root) { signInResult, error in
+                    guard error == nil, let result = signInResult else { return }
+                    let email = result.user.profile?.email ?? result.user.userID ?? ""
+                    onLogin(email)
+                }
+            }
+            .frame(height: 45)
+            .padding(.horizontal)
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- enable Apple and Google authentication in LoginView

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project EisenhowerMatrixApp.xcodeproj -scheme EisenhowerMatrixApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f216ae96c8329aa5f0e6f1a4f5a6c