### PR TITLE
Rename task terminology to priority in UI

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -472,7 +472,7 @@ struct ContentView: View {
                         Image(systemName: "plus.circle.fill")
                             .foregroundColor(color)
                             .font(.caption)
-                        Text("Add Task")
+                        Text("Add Priority")
                             .font(.caption)
                             .foregroundColor(color)
                     }
@@ -496,7 +496,7 @@ struct ContentView: View {
     }
 }
 
-// MARK: - Add Task View
+// MARK: - Add Priority View
 struct AddTaskView: View {
     @ObservedObject var taskManager: TaskManager
     let priority: TaskPriority
@@ -510,8 +510,8 @@ struct AddTaskView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Task Details")) {
-                    TextField("Task title", text: $title)
+                Section(header: Text("Priority Details")) {
+                    TextField("Priority title", text: $title)
                     TextField("Description", text: $description)
                 }
 
@@ -528,7 +528,7 @@ struct AddTaskView: View {
                         .fontWeight(.semibold)
                 }
             }
-            .navigationTitle("Add Task")
+            .navigationTitle("Add Priority")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -581,7 +581,7 @@ struct PriorityDetailView: View {
                         }
 
                         HStack {
-                            Text("\(activeTasks.count) tasks")
+                            Text("\(activeTasks.count) priorities")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
 
@@ -649,7 +649,7 @@ struct PriorityDetailView: View {
         case .notUrgentImportant:
             return "Schedule - Plan these for later"
         case .notUrgentNotImportant:
-            return "Eliminate - Consider removing these tasks"
+            return "Eliminate - Consider removing these priorities"
         }
     }
     
@@ -702,7 +702,7 @@ struct TaskRowView: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 if isEditing {
-                    TextField("Task title", text: $editedTitle)
+                    TextField("Priority title", text: $editedTitle)
                         .font(.body)
                         .fontWeight(.medium)
                         .onSubmit {
@@ -771,7 +771,7 @@ struct TaskRowView: View {
     }
 }
 
-// MARK: - Edit Task View
+// MARK: - Edit Priority View
 struct EditTaskView: View {
     @ObservedObject var taskManager: TaskManager
     let task: TaskItem
@@ -796,8 +796,8 @@ struct EditTaskView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Task Details")) {
-                    TextField("Task title", text: $title)
+                Section(header: Text("Priority Details")) {
+                    TextField("Priority title", text: $title)
                     TextField("Description", text: $description)
                 }
 
@@ -819,7 +819,7 @@ struct EditTaskView: View {
                     .pickerStyle(MenuPickerStyle())
                 }
             }
-            .navigationTitle("Edit Task")
+            .navigationTitle("Edit Priority")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -836,7 +836,7 @@ struct EditTaskView: View {
     }
 }
 
-// MARK: - Task Detail View
+// MARK: - Priority Item Detail View
 struct TaskDetailView: View {
     let task: TaskItem
     @ObservedObject var taskManager: TaskManager
@@ -935,7 +935,7 @@ struct TaskDetailView: View {
 
                 Spacer()
             }
-            .navigationTitle("Task Details")
+            .navigationTitle("Priority Details")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
@@ -961,7 +961,7 @@ struct TaskDetailView: View {
         case .notUrgentImportant:
             return "Schedule - Plan these for later"
         case .notUrgentNotImportant:
-            return "Eliminate - Consider removing these tasks"
+            return "Eliminate - Consider removing these priorities"
         }
     }
 }

--- a/EisenhowerMatrixApp_iOS/ContentView.swift
+++ b/EisenhowerMatrixApp_iOS/ContentView.swift
@@ -472,7 +472,7 @@ struct ContentView: View {
                         Image(systemName: "plus.circle.fill")
                             .foregroundColor(color)
                             .font(.caption)
-                        Text("Add Task")
+                        Text("Add Priority")
                             .font(.caption)
                             .foregroundColor(color)
                     }
@@ -496,7 +496,7 @@ struct ContentView: View {
     }
 }
 
-// MARK: - Add Task View
+// MARK: - Add Priority View
 struct AddTaskView: View {
     @ObservedObject var taskManager: TaskManager
     let priority: TaskPriority
@@ -510,8 +510,8 @@ struct AddTaskView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Task Details")) {
-                    TextField("Task title", text: $title)
+                Section(header: Text("Priority Details")) {
+                    TextField("Priority title", text: $title)
                     TextField("Description", text: $description)
                 }
 
@@ -528,7 +528,7 @@ struct AddTaskView: View {
                         .fontWeight(.semibold)
                 }
             }
-            .navigationTitle("Add Task")
+            .navigationTitle("Add Priority")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -581,7 +581,7 @@ struct PriorityDetailView: View {
                         }
 
                         HStack {
-                            Text("\(activeTasks.count) tasks")
+                            Text("\(activeTasks.count) priorities")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
 
@@ -649,7 +649,7 @@ struct PriorityDetailView: View {
         case .notUrgentImportant:
             return "Schedule - Plan these for later"
         case .notUrgentNotImportant:
-            return "Eliminate - Consider removing these tasks"
+            return "Eliminate - Consider removing these priorities"
         }
     }
     
@@ -702,7 +702,7 @@ struct TaskRowView: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 if isEditing {
-                    TextField("Task title", text: $editedTitle)
+                    TextField("Priority title", text: $editedTitle)
                         .font(.body)
                         .fontWeight(.medium)
                         .onSubmit {
@@ -771,7 +771,7 @@ struct TaskRowView: View {
     }
 }
 
-// MARK: - Edit Task View
+// MARK: - Edit Priority View
 struct EditTaskView: View {
     @ObservedObject var taskManager: TaskManager
     let task: TaskItem
@@ -796,8 +796,8 @@ struct EditTaskView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Task Details")) {
-                    TextField("Task title", text: $title)
+                Section(header: Text("Priority Details")) {
+                    TextField("Priority title", text: $title)
                     TextField("Description", text: $description)
                 }
 
@@ -819,7 +819,7 @@ struct EditTaskView: View {
                     .pickerStyle(MenuPickerStyle())
                 }
             }
-            .navigationTitle("Edit Task")
+            .navigationTitle("Edit Priority")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -836,7 +836,7 @@ struct EditTaskView: View {
     }
 }
 
-// MARK: - Task Detail View
+// MARK: - Priority Item Detail View
 struct TaskDetailView: View {
     let task: TaskItem
     @ObservedObject var taskManager: TaskManager
@@ -935,7 +935,7 @@ struct TaskDetailView: View {
 
                 Spacer()
             }
-            .navigationTitle("Task Details")
+            .navigationTitle("Priority Details")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
@@ -961,7 +961,7 @@ struct TaskDetailView: View {
         case .notUrgentImportant:
             return "Schedule - Plan these for later"
         case .notUrgentNotImportant:
-            return "Eliminate - Consider removing these tasks"
+            return "Eliminate - Consider removing these priorities"
         }
     }
 }


### PR DESCRIPTION
## Summary
- change Add Task UI wording to Add Priority
- update section headers and details to mention Priority
- show priority count and eliminate guidance using "priorities"

## Testing
- `xcodebuild -project EisenhowerMatrixApp.xcodeproj -scheme EisenhowerMatrixApp build` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cccb5d0c8329841c0e99fa0f4bea