### PR TITLE
Allow tapping quadrant space to open priority list

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -449,16 +449,20 @@ struct ContentView: View {
                                 .fontWeight(.medium)
                         }
                         .onDrop(of: [UTType.plainText], delegate: QuadrantDropDelegate(
-                            priority: priority, 
-                            taskManager: taskManager, 
+                            priority: priority,
+                            taskManager: taskManager,
                             draggedTaskId: $draggedTaskId
                         ))
                     }
                 }
             }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                selectedPriority = priority
+            }
             .onDrop(of: [UTType.plainText], delegate: QuadrantDropDelegate(
-                priority: priority, 
-                taskManager: taskManager, 
+                priority: priority,
+                taskManager: taskManager,
                 draggedTaskId: $draggedTaskId
             ))
 
@@ -488,9 +492,13 @@ struct ContentView: View {
             Rectangle()
                 .stroke(color, lineWidth: 1)
         )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedPriority = priority
+        }
         .onDrop(of: [UTType.plainText], delegate: QuadrantDropDelegate(
-            priority: priority, 
-            taskManager: taskManager, 
+            priority: priority,
+            taskManager: taskManager,
             draggedTaskId: $draggedTaskId
         ))
     }


### PR DESCRIPTION
## Summary
- open a quadrant's task list when tapping anywhere in the quadrant, not just the header

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cd8cc8a4832996ec7690791f50ce