### PR TITLE
Default landing screen to dark and limit background modes

### DIFF
--- a/EisenhowerMatrixApp/ContentView.swift
+++ b/EisenhowerMatrixApp/ContentView.swift
@@ -90,7 +90,6 @@ enum TaskPriority: String, CaseIterable, Codable, Identifiable {
 // MARK: - App Appearance
 enum BackgroundMode: String, CaseIterable, Identifiable {
     case dark = "Dark"
-    case gray = "Gray"
     case white = "White"
 
     var id: String { rawValue }
@@ -99,8 +98,6 @@ enum BackgroundMode: String, CaseIterable, Identifiable {
         switch self {
         case .dark:
             return .black
-        case .gray:
-            return Color(red: 0.7, green: 0.7, blue: 0.7)
         case .white:
             return .white
         }
@@ -334,7 +331,7 @@ struct ContentView: View {
     @State private var showingTaskDetail = false
     @State private var isDragging = false
     @State private var draggedTaskId: UUID?
-    @State private var backgroundMode: BackgroundMode = .white
+    @State private var backgroundMode: BackgroundMode = .dark
     
     var body: some View {
         NavigationView {

--- a/EisenhowerMatrixApp_iOS/ContentView.swift
+++ b/EisenhowerMatrixApp_iOS/ContentView.swift
@@ -90,7 +90,6 @@ enum TaskPriority: String, CaseIterable, Codable, Identifiable {
 // MARK: - App Appearance
 enum BackgroundMode: String, CaseIterable, Identifiable {
     case dark = "Dark"
-    case gray = "Gray"
     case white = "White"
 
     var id: String { rawValue }
@@ -99,8 +98,6 @@ enum BackgroundMode: String, CaseIterable, Identifiable {
         switch self {
         case .dark:
             return .black
-        case .gray:
-            return Color(red: 0.7, green: 0.7, blue: 0.7)
         case .white:
             return .white
         }
@@ -334,7 +331,7 @@ struct ContentView: View {
     @State private var showingTaskDetail = false
     @State private var isDragging = false
     @State private var draggedTaskId: UUID?
-    @State private var backgroundMode: BackgroundMode = .white
+    @State private var backgroundMode: BackgroundMode = .dark
     
     var body: some View {
         NavigationView {


### PR DESCRIPTION
## Summary
- Make dark the default background for landing screen.
- Remove gray background option so only Dark and White modes remain.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cdfd0a948329bd5392c4fefdf1ee